### PR TITLE
UI prototype search entry

### DIFF
--- a/client/.stylelintrc
+++ b/client/.stylelintrc
@@ -109,7 +109,6 @@
     "media-query-list-comma-space-after": "always",
     "media-query-list-comma-space-before": "never",
     "no-descending-specificity": true,
-    "no-duplicate-selectors": true,
     "no-empty-source": true,
     "no-eol-whitespace": true,
     "no-extra-semicolons": true,

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -27,20 +27,36 @@ const environment = optionsSetAtInvocation.environment || 'development';
 const config = {
   sources: {
     directories: {
+      markup: 'src',
       scss: 'src/scss',
       js: 'src/js'
     }
   },
   outputPaths: {
+    markup: 'build',
     css: `build/css`,
     js: 'build/js'
   }
 };
 
 config.sources.files = {
+  markup: `${config.sources.directories.markup}/**/*.html`,
   scss: `${config.sources.directories.scss}/**/*.scss`,
   js: `${config.sources.directories.js}/**/*.js`
 };
+
+gulp.task('markup:watch', () => {
+  gulp.watch(config.sources.files.markup, ['copyHTML']);
+});
+
+gulp.task('copyHTML', () => {
+  gulp.src(config.sources.files.markup)
+    .pipe(gulp.dest(config.outputPaths.markup));
+});
+
+gulp.task('css:watch', () => {
+  gulp.watch(config.sources.files.scss, ['css']);
+});
 
 gulp.task('css', ['sass:lint'], () => {
   const options = environment === 'production' ? { outputStyle: 'compressed' } : null;
@@ -61,7 +77,7 @@ gulp.task('sass:lint', ['sass:clean'], () => {
     reporter({ clearMessages: true, throwError: true  })
   ];
 
-  return gulp.src([config.sources.files.scss])
+  return gulp.src([config.sources.files.scss, `!${config.sources.directories.scss}/_normalize.scss`])
              .pipe(postcss(processors, { syntax: syntaxScss }));
 });
 
@@ -97,5 +113,27 @@ gulp.task('js:lint', () => {
              .pipe(eslint.failAfterError());
 });
 
-gulp.task('build', ['css', 'js']);
+gulp.task('serve', ['build'], () => {
+
+  browserSync.init({
+                     browser: ['google chrome'],
+                     startPath: '/search-UI-prototypes.html',
+                     server: {
+                       baseDir: `build/`
+                     }
+                   });
+
+  // gulp.watch([config.sources.files.js], ['js:watch']);
+  gulp.watch([config.sources.files.scss], ['css']);
+  gulp.watch([config.sources.files.markup], ['markup']);
+});
+
+gulp.task('markup:markup', ['copyHTML'], (done) => {
+  browserSync.reload();
+  done();
+});
+
+
+gulp.task('build', ['css', 'js', 'copyHTML']);
+gulp.task('watch', ['serve']);
 gulp.task('default', ['build']);

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -125,7 +125,7 @@ gulp.task('serve', ['build'], () => {
 
   // gulp.watch([config.sources.files.js], ['js:watch']);
   gulp.watch([config.sources.files.scss], ['css']);
-  gulp.watch([config.sources.files.markup], ['markup']);
+  gulp.watch([config.sources.files.markup], ['copyHTML']);
 });
 
 gulp.task('markup:markup', ['copyHTML'], (done) => {

--- a/client/src/scss/_incTest.scss
+++ b/client/src/scss/_incTest.scss
@@ -1,3 +1,0 @@
-body {
-  color: blue;
-}

--- a/client/src/scss/_normalize.scss
+++ b/client/src/scss/_normalize.scss
@@ -1,0 +1,426 @@
+/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
+
+/**
+ * 1. Set default font family to sans-serif.
+ * 2. Prevent iOS and IE text size adjust after device orientation change,
+ *    without disabling user zoom.
+ */
+
+html {
+  font-family: sans-serif; /* 1 */
+  -ms-text-size-adjust: 100%; /* 2 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/**
+ * Remove default margin.
+ */
+
+body {
+  margin: 0;
+}
+
+/* HTML5 display definitions
+   ========================================================================== */
+
+/**
+ * Correct `block` display not defined for any HTML5 element in IE 8/9.
+ * Correct `block` display not defined for `details` or `summary` in IE 10/11
+ * and Firefox.
+ * Correct `block` display not defined for `main` in IE 11.
+ */
+
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+main,
+menu,
+nav,
+section,
+summary {
+  display: block;
+}
+
+/**
+ * 1. Correct `inline-block` display not defined in IE 8/9.
+ * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+ */
+
+audio,
+canvas,
+picture,
+progress,
+video {
+  display: inline-block; /* 1 */
+  vertical-align: baseline; /* 2 */
+}
+
+/**
+ * Prevent modern browsers from displaying `audio` without controls.
+ * Remove excess height in iOS 5 devices.
+ */
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+/**
+ * Address `[hidden]` styling not present in IE 8/9/10.
+ * Hide the `template` element in IE 8/9/10/11, Safari, and Firefox < 22.
+ */
+
+[hidden],
+template {
+  display: none;
+}
+
+/* Links
+   ========================================================================== */
+
+/**
+ * Remove the gray background color from active links in IE 10.
+ */
+
+a {
+  background-color: transparent;
+}
+
+/**
+ * Improve readability of focused elements when they are also in an
+ * active/hover state.
+ */
+
+a:active,
+a:hover {
+  outline: 0;
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * Address inconsistent styling of `abbr[title]`.
+ * 1. Correct styling in Firefox 39 and Opera 12.
+ * 2. Correct missing styling in Chrome, Edge, IE, Opera, and Safari.
+ */
+
+abbr[title] {
+  border-bottom: none; /* 1 */
+  text-decoration: underline; /* 2 */
+  text-decoration: underline dotted; /* 2 */
+}
+
+/**
+ * Address inconsistent styling of b and strong.
+ * 1. Correct duplicate application of `bolder` in Safari 6.0.2.
+ * 2. Correct style set to `bold` in Edge 12+, Safari 6.2+, and Chrome 18+.
+ */
+
+b,
+strong {
+  font-weight: inherit; /* 1 */
+}
+
+b,
+strong {
+  font-weight: bolder; /* 2 */
+}
+
+/**
+ * Address styling not present in Safari and Chrome.
+ */
+
+dfn {
+  font-style: italic;
+}
+
+/**
+ * Address variable `h1` font-size and margin within `section` and `article`
+ * contexts in Firefox 4+, Safari, and Chrome.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/**
+ * Address styling not present in IE 8/9.
+ */
+
+mark {
+  background-color: #ff0;
+  color: #000;
+}
+
+/**
+ * Address inconsistent and variable font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` affecting `line-height` in all browsers.
+ */
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sup {
+  top: -0.5em;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Remove border when inside `a` element in IE 8/9/10.
+ */
+
+img {
+  border: 0;
+}
+
+/**
+ * Correct overflow not hidden in IE 9/10/11.
+ */
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * Address margin not present in IE 8/9 and Safari.
+ */
+
+figure {
+  margin: 1em 40px;
+}
+
+/**
+ * Address inconsistent styling of `hr`.
+ * 1. Correct `box-sizing` set to `border-box` in Firefox.
+ * 2. Correct `overflow` set to `hidden` in IE 8/9/10/11 and Edge 12.
+ */
+
+hr {
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
+}
+
+/**
+ * Contain overflow in all browsers.
+ */
+
+pre {
+  overflow: auto;
+}
+
+/**
+ * 1. Correct inheritance and scaling of font-size for preformatted text.
+ * 2. Address odd `em`-unit font size rendering in all browsers.
+ */
+
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * Known limitation: by default, Chrome and Safari on OS X allow very limited
+ * styling of `select`, unless a `border` property is set.
+ */
+
+/**
+ * 1. Correct font properties not being inherited.
+ * 2. Address margins set differently in Firefox 4+, Safari, and Chrome.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font: inherit; /* 1 */
+  margin: 0; /* 2 */
+}
+
+/**
+ * Address `overflow` set to `hidden` in IE 8/9/10/11.
+ */
+
+button {
+  overflow: visible;
+}
+
+/**
+ * Address inconsistent `text-transform` inheritance for `button` and `select`.
+ * All other form control elements do not inherit `text-transform` values.
+ * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+ * Correct `select` style inheritance in Firefox.
+ */
+
+button,
+select {
+  text-transform: none;
+}
+
+/**
+ * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+ *    and `video` controls.
+ * 2. Correct inability to style clickable `input` types in iOS.
+ * 3. Improve usability and consistency of cursor style between image-type
+ *    `input` and others.
+ */
+
+button,
+html input[type="button"], /* 1 */
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button; /* 2 */
+  cursor: pointer; /* 3 */
+}
+
+/**
+ * Re-set default cursor for disabled elements.
+ */
+
+button[disabled],
+html input[disabled] {
+  cursor: default;
+}
+
+/**
+ * Remove inner padding and border in Firefox 4+.
+ */
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+/**
+ * Restore focus style in Firefox 4+ (unset by a rule above)
+ */
+
+button:-moz-focusring,
+input:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+/**
+ * Address Firefox 4+ setting `line-height` on `input` using `!important` in
+ * the UA stylesheet.
+ */
+
+input {
+  line-height: normal;
+}
+
+/**
+ * It's recommended that you don't attempt to style these elements.
+ * Firefox's implementation doesn't respect box-sizing, padding, or width.
+ *
+ * 1. Address box sizing set to `content-box` in IE 8/9/10.
+ * 2. Remove excess padding in IE 8/9/10.
+ */
+
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Udpate the cursor style for Chrome's increment/decrement buttons. For certain
+ * `font-size` values of the `input`, it causes the cursor style of the
+ * decrement button to change from `default` to `text`.
+ */
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * Address `appearance` set to `searchfield` in Safari and Chrome.
+ */
+
+input[type="search"] {
+  -webkit-appearance: textfield;
+}
+
+/**
+ * Remove inner padding and search cancel button in Safari and Chrome on OS X.
+ * Safari (but not Chrome) clips the cancel button when the search input has
+ * padding (and `textfield` appearance).
+ */
+
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * Define consistent border, margin, and padding.
+ */
+
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+/**
+ * 1. Correct `color` not being inherited in IE 8/9/10/11.
+ * 2. Remove padding so people aren't caught out if they zero out fieldsets.
+ */
+
+legend {
+  border: 0; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Remove default vertical scrollbar in IE 8/9/10/11.
+ */
+
+textarea {
+  overflow: auto;
+}
+
+/**
+ * Restore font weight (unset by a rule above).
+ * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+ */
+
+optgroup {
+  font-weight: bold;
+}

--- a/client/src/scss/_variables.scss
+++ b/client/src/scss/_variables.scss
@@ -1,0 +1,33 @@
+//------------------------------------
+//    $VARIABLES
+//------------------------------------
+
+// Colors
+$color-primary: #0288d1;
+$color-primary-dark: #0277bd;
+$color-primary-light: #b3e5fc;
+
+$color-text: #212121;
+$color-text-secondary: #888;
+$color-text-placeholder: #bdbdbd;
+$color-text-dividers: #e0e0e0;
+$color-text-ui-background: #fff;
+$color-text-ui-background-hue: #f5f5f5;
+$color-text-ui-code: #f7f7f7;
+
+$color-text--reverse: #fff;
+$color-text-secondary--reverse: #9e9e9e;
+// there is no $color-text-placeholder--reverse
+$color-text-dividers--reverse: #616161;
+$color-text-ui-background--reverse: #212121;
+$color-text-ui-background-hue--reverse: #333;
+
+$color-information: #0288d1;
+$color-success: #629f43;
+$color-success-dark: #569037;
+$color-attention: #cf0c4e;
+
+$color-overlay: rgba(0, 0, 0, 0.8);
+
+$breakpoint_1: 780;
+$breakpoint_2: 900;

--- a/client/src/scss/base.scss
+++ b/client/src/scss/base.scss
@@ -1,5 +1,115 @@
+* {
+  box-sizing: border-box;
+}
+
 body {
   font-family: "noto sans", sans-serif;
   font-size: 16px;
+  padding: 8px;
+  color: #363636;
+
+  @media only all and (min-width: #{$breakpoint_2}px) {
+    margin: 0 auto;
+    max-width: 800px;
+  }
+}
+
+fieldset {
+  border-radius: 5px;
+}
+
+fieldset,
+header {
+  margin: 24px 0;
+}
+
+[type="radio"] {
+  margin-right: 12px;
+}
+
+[type="search"] {
+  border-radius: 5px;
+  border: 1px solid $color-primary;
+  line-height: 2;
+  padding: 0 8px;
+  width: 48%;
+
+  @media only all and (min-width: #{$breakpoint_1}px) {
+    width: 50%;
+  }
+}
+
+button {
+  background-color: $color-primary;
+  border-image: none;
+  border-radius: 5px;
+  color: $color-text--reverse;
+  line-height: 2;
+  width: 48%;
+
+  &:hover {
+    background-color: $color-primary-dark;
+  }
+
+}
+
+fieldset {
+  border: 1px solid $color-primary;
+  width: 96%;
+
+  @media only all and (min-width: #{$breakpoint_1}px) {
+    width: 50%;
+  }
+
+}
+
+.lang-picker-wrapper {
+  @media only all and (min-width: #{$breakpoint_1}px) {
+    float: right;
+    clear: right;
+    margin: 24px 8px;
+    width: 42%;
+  }
+
+}
+
+.lang-picker {
+  display: block;
+}
+
+legend {
+  padding: 0 12px;
+  &:before,
+  &:after {
+    content: " ";
+  }
+}
+
+.id-type-wrapper {
+  @media only all and (min-width: #{$breakpoint_1}px) {
+    float: left;
+  }
+
+}
+
+.date-picker {
+  clear: left;
+
+  @media only all and (min-width: #{$breakpoint_1}px) {
+    clear: none;
+    float: left;
+    margin-left: 1%;
+    margin-top: 0;
+    width: 49%;
+  }
+}
+
+[type="date"] {
+  border: none;
+  color: $color-primary;
+}
+
+.multi-choice-item {
+  line-height: 1.65;
 }
 

--- a/client/src/scss/base.scss
+++ b/client/src/scss/base.scss
@@ -1,0 +1,5 @@
+body {
+  font-family: "noto sans", sans-serif;
+  font-size: 16px;
+}
+

--- a/client/src/scss/build.scss
+++ b/client/src/scss/build.scss
@@ -1,7 +1,3 @@
-@import "incTest";
+@import "normalize";
 
-div {
-  &.div {
-    color: red;
-  }
-}
+@import "base";

--- a/client/src/scss/build.scss
+++ b/client/src/scss/build.scss
@@ -1,3 +1,4 @@
+@import "variables";
 @import "normalize";
 
 @import "base";

--- a/client/src/search-UI-prototypes.html
+++ b/client/src/search-UI-prototypes.html
@@ -16,26 +16,26 @@
 
     <form>
 
-      <input class="text-input" type="search" placeholder="10.nnnn.nn ...">
+      <input class="text-input" type="search" placeholder="10.nnnn.nn formatted search">
       <button class="button" type="submit">Search</button>
 
 
-      <fieldset>
-        <legend>Choose which type of identifier you're searching with </legend>
+      <fieldset class="id-type-wrapper">
+        <legend>Which type of identifier are you searching with? </legend>
 
-        <div><input type="radio" name="idPicker" id="idPickerDOI" checked/><label for="idPickerDOI">DOI</label></div>
-        <div><input type="radio" name="idPicker" id="idPickerISBN" /><label for="idPickerISBN">ISBN</label></div>
-        <div><input type="radio" name="idPicker" id="idPickerARXIV" /><label for="idPickerARXIV">ARXIV</label></div>
-        <div><input type="radio" name="idPicker" id="idPickerPMID" /><label for="idPickerPMID">PubMed ID</label></div>
-        <div><input type="radio" name="idPicker" id="idPickerPMCID" /><label for="idPickerPMCID">PubMed Central ID</label></div>
+        <div class="multi-choice-item"><input type="radio" name="idPicker" id="idPickerDOI" checked/><label for="idPickerDOI">DOI</label></div>
+        <div class="multi-choice-item"><input type="radio" name="idPicker" id="idPickerISBN" /><label for="idPickerISBN">ISBN</label></div>
+        <div class="multi-choice-item"><input type="radio" name="idPicker" id="idPickerARXIV" /><label for="idPickerARXIV">ARXIV</label></div>
+        <div class="multi-choice-item"><input type="radio" name="idPicker" id="idPickerPMID" /><label for="idPickerPMID">PubMed ID</label></div>
+        <div class="multi-choice-item"><input type="radio" name="idPicker" id="idPickerPMCID" /><label for="idPickerPMCID">PubMed Central ID</label></div>
 
       </fieldset>
 
 
-      <div>
-        <label for="langPicker">Choose a languge (or by default search across all languages)</label>
+      <div class="lang-picker-wrapper">
+        <label for="langPicker">Choose a language (by default searches across all languages)</label>
 
-        <select id="langPicker">
+        <select id="langPicker" class="lang-picker">
           <option value="all" selected>All</option>
           <option value="EN">English</option>
           <option value="DE">German</option>
@@ -46,8 +46,8 @@
       </div>
 
 
-      <fieldset>
-        <legend>Pick a date range.</legend>
+      <fieldset class="date-picker">
+        <legend>Pick a date range</legend>
         <div><label for="datePickerStart">Choose a start date</label>: <input type="date" id="datePickerStart"></div>
         <div><label for="datePickerEnd">Choose an end date</label>: <input type="date" id="datePickerEnd"></div>
       </fieldset>

--- a/client/src/search-UI-prototypes.html
+++ b/client/src/search-UI-prototypes.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>WikiCiteVis: Search UI prototype</title>
+  <link rel="stylesheet" href="css/all.css">
+</head>
+<body>
+
+  <main>
+
+    <header class=page-header">
+      <h1 class=page-header__heading">WikiCiteVis</h1>
+      <p class=page-header__stand_first">[Some words about the tool.]</p>
+    </header>
+
+    <form>
+
+      <input class="text-input" type="search" placeholder="10.nnnn.nn ...">
+      <button class="button" type="submit">Search</button>
+
+
+      <fieldset>
+        <legend>Choose which type of identifier you're searching with </legend>
+
+        <div><input type="radio" name="idPicker" id="idPickerDOI" checked/><label for="idPickerDOI">DOI</label></div>
+        <div><input type="radio" name="idPicker" id="idPickerISBN" /><label for="idPickerISBN">ISBN</label></div>
+        <div><input type="radio" name="idPicker" id="idPickerARXIV" /><label for="idPickerARXIV">ARXIV</label></div>
+        <div><input type="radio" name="idPicker" id="idPickerPMID" /><label for="idPickerPMID">PubMed ID</label></div>
+        <div><input type="radio" name="idPicker" id="idPickerPMCID" /><label for="idPickerPMCID">PubMed Central ID</label></div>
+
+      </fieldset>
+
+
+      <div>
+        <label for="langPicker">Choose a languge (or by default search across all languages)</label>
+
+        <select id="langPicker">
+          <option value="all" selected>All</option>
+          <option value="EN">English</option>
+          <option value="DE">German</option>
+          <option value="ES">Spanish</option>
+          <option value="">...</option>
+        </select>
+
+      </div>
+
+
+      <fieldset>
+        <legend>Pick a date range.</legend>
+        <div><label for="datePickerStart">Choose a start date</label>: <input type="date" id="datePickerStart"></div>
+        <div><label for="datePickerEnd">Choose an end date</label>: <input type="date" id="datePickerEnd"></div>
+      </fieldset>
+
+    </form>
+
+
+
+  </main>
+
+
+</body>
+</html>

--- a/client/src/search-UI-prototypes.html
+++ b/client/src/search-UI-prototypes.html
@@ -11,7 +11,8 @@
 
     <header class=page-header">
       <h1 class=page-header__heading">WikiCiteVis</h1>
-      <p class=page-header__stand_first">[Some words about the tool.]</p>
+      <p class=page-header__stand_first">WikiCiteVis is a tool to search and visualise Wikipedia's citation data, using the <a href="https://figshare.com/articles/Wikipedia_Scholarly_Article_Citations/1299540">Citations with identifiers in Wikipedia</a> dataset.</p>
+      <p>The data only contains identifiers present on March 1, 2018, so any added since then will not be present in this tool. Approximately 98% of identifiers resolve, which may mean you come across identifiers in this tool that aren't valid.</p>
     </header>
 
     <form>


### PR DESCRIPTION
This PR contains a UI prototype (HTML & CSS) for the search entry view.

Generate by running `./node_modules/.bin/gulp watch`.

Screen shots included below.

## Narrow view:
<img width="581" alt="screenshot 2018-05-11 01 27 58" src="https://user-images.githubusercontent.com/2893480/39900589-b91199fc-54ba-11e8-9e09-e20f21f9000c.png">

## Wider view:
<img width="841" alt="screenshot 2018-05-11 01 28 08" src="https://user-images.githubusercontent.com/2893480/39900588-b7f74c38-54ba-11e8-8175-0831bbe0095c.png">
