### PR TITLE
Allow collectstatic to run a second time

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     command: >
             /bin/bash -c "
                 until echo > /dev/tcp/postgres/5432; do sleep 1; done
-                python manage.py collectstatic
+                python manage.py collectstatic --noinput
                 python manage.py migrate citations
                 python manage.py migrate
                 gunicorn -b 0.0.0.0:8000 "core.wsgi"


### PR DESCRIPTION
Since `static` is stored in a volume https://github.com/Samwalton9/WikiCiteVis/blob/92d08005de9a6204fe806656539e73a13bac5d57/docker-compose.yml#L18 it's currently failing the second time round as it expects input.