### PR TITLE
Hookup front end to api

### DIFF
--- a/client/.docker/nginx.conf
+++ b/client/.docker/nginx.conf
@@ -13,7 +13,7 @@ server {
     }
 
     location / {
-        proxy_pass http://client:3000;
+        proxy_pass http://client:8080;
         proxy_buffering off;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }

--- a/client/.stylelintrc
+++ b/client/.stylelintrc
@@ -108,7 +108,6 @@
     "media-query-list-comma-newline-before": "never-multi-line",
     "media-query-list-comma-space-after": "always",
     "media-query-list-comma-space-before": "never",
-    "no-descending-specificity": true,
     "no-empty-source": true,
     "no-eol-whitespace": true,
     "no-extra-semicolons": true,

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -6,6 +6,11 @@ COPY package.json package-lock.json /srv/app/
 
 RUN npm install --force
 
+RUN npm install http-server -g
+
 COPY . .
 
-CMD node_modules/.bin/gulp serve
+RUN node_modules/.bin/gulp build
+
+CMD http-server build/
+

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -4,7 +4,9 @@
   <meta charset="UTF-8">
   <title>WikiCiteVis</title>
   <link rel="stylesheet" href="css/all.css">
-</head>
+  <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
+
+  <meta name="format-detection" content="telephone=no"></head>
 <body>
 
   <main>

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -61,11 +61,7 @@
 
     </section>
 
-
-    <section class="search-results">
-      <h2 class="heading" id="searchResultsHeading">Search results</h2>
-
-    </section>
+    <section class="search-results" aria-live="polite"></section>
 
 
   </main>

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -17,16 +17,17 @@
 
     <section class="search-entry">
 
-      <form id="searchForm" method="get" action="PUBLIC_API_URI/api/v1/citations/">
+      <!--<form id="searchForm" method="get" action="PUBLIC_API_URI/api/v1/citations/">-->
+      <form id="searchForm" method="get" action="http://54.229.175.46:8081/api/v1/citations/">
 
-        <input class="text-input" type="search" name="search" placeholder="10.nnnn.nn formatted search">
+      <input class="text-input" type="search" name="search" placeholder="10.nnnn.nn formatted search">
         <button class="button" type="submit">Search</button>
 
 
         <fieldset class="id-type-wrapper">
           <legend>Which type of identifier are you searching with? </legend>
 
-          <div class="multi-choice-item"><input type="radio" name="type" value="doi" id="idPickerDOI"/><label for="idPickerDOI">DOI</label></div>
+          <div class="multi-choice-item"><input type="radio" name="type" value="doi" id="idPickerDOI" checked/><label for="idPickerDOI">DOI</label></div>
           <div class="multi-choice-item"><input type="radio" name="type" value="isbn" id="idPickerISBN" /><label for="idPickerISBN">ISBN</label></div>
           <div class="multi-choice-item"><input type="radio" name="type" value="arxiv" id="idPickerARXIV" /><label for="idPickerARXIV">ARXIV</label></div>
           <div class="multi-choice-item"><input type="radio" name="type" value="pmid" id="idPickerPMID" /><label for="idPickerPMID">PubMed ID</label></div>
@@ -43,6 +44,7 @@
           <option name="language" value="en">English</option>
           <option name="language" value="de">German</option>
           <option name="language" value="es">Spanish</option>
+          <option name="language">...</option>
 
         </select>
 

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -23,7 +23,7 @@
       <form id="searchForm" method="get" action="http://54.229.175.46:8081/api/v1/citations/">
 
         <div class="search-text-and-go">
-          <input class="text-input" type="search" name="search" placeholder="10.nnnn.nn formatted search" />
+          <input class="text-input" type="search" name="search" />
           <button class="button" type="submit">Search</button>
         </div>
 

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -27,6 +27,8 @@
           <button class="button" type="submit">Search</button>
         </div>
 
+        <div class="multi-choice-item"><input type="checkbox" name="stringency" value="exact match" id="stringency" checked/><label for="stringency">Exact match</label></div>
+
         <div class="pickers">
           <fieldset class="id-type-wrapper">
             <legend>Which type of identifier are you searching with? </legend>

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -45,12 +45,278 @@
             <label for="langPicker">Choose a language (by default searches across all languages)</label>
 
             <select name="language" id="langPicker" class="lang-picker">
-              <option name="language" value="" selected>All</option>
-              <option name="language" value="en">English</option>
-              <option name="language" value="de">German</option>
-              <option name="language" value="es">Spanish</option>
-              <option name="language">...</option>
+              <option name="language"value="" selected>All</option>
 
+              <option name="language" value="AA">AA (Aruba)</option>
+              <option name="language" value="AC">AC (Antigua and Barbuda)</option>
+              <option name="language" value="AE">AE (United Arab Emirates)</option>
+              <option name="language" value="AF">AF (Afghanistan)</option>
+              <option name="language" value="AG">AG (Algeria)</option>
+              <option name="language" value="AJ">AJ (Azerbaijan)</option>
+              <option name="language" value="AL">AL (Albania)</option>
+              <option name="language" value="AM">AM (Armenia)</option>
+              <option name="language" value="AN">AN (Andorra)</option>
+              <option name="language" value="AO">AO (Angola)</option>
+              <option name="language" value="AQ">AQ (American Samoa)</option>
+              <option name="language" value="AR">AR (Argentina)</option>
+              <option name="language" value="AS">AS (Australia)</option>
+              <option name="language" value="AT">AT (Ashmore and Cartier Islands)</option>
+              <option name="language" value="AU">AU (Austria)</option>
+              <option name="language" value="AV">AV (Anguilla)</option>
+              <option name="language" value="AX">AX (Akrotiri)</option>
+              <option name="language" value="AY">AY (Antarctica)</option>
+              <option name="language" value="BA">BA (Bahrain)</option>
+              <option name="language" value="BB">BB (Barbados)</option>
+              <option name="language" value="BC">BC (Botswana)</option>
+              <option name="language" value="BD">BD (Bermuda)</option>
+              <option name="language" value="BE">BE (Belgium)</option>
+              <option name="language" value="BF">BF (Bahamas, The)</option>
+              <option name="language" value="BG">BG (Bangladesh)</option>
+              <option name="language" value="BH">BH (Belize)</option>
+              <option name="language" value="BK">BK (Bosnia and Herzegovina)</option>
+              <option name="language" value="BL">BL (Bolivia)</option>
+              <option name="language" value="BM">BM (Burma)</option>
+              <option name="language" value="BN">BN (Benin)</option>
+              <option name="language" value="BO">BO (Belarus)</option>
+              <option name="language" value="BP">BP (Solomon Islands)</option>
+              <option name="language" value="BQ">BQ (Navassa Island)</option>
+              <option name="language" value="BR">BR (Brazil)</option>
+              <option name="language" value="BS">BS (Bassas da India)</option>
+              <option name="language" value="BT">BT (Bhutan)</option>
+              <option name="language" value="BU">BU (Bulgaria)</option>
+              <option name="language" value="BV">BV (Bouvet Island)</option>
+              <option name="language" value="BX">BX (Brunei)</option>
+              <option name="language" value="BY">BY (Burundi)</option>
+              <option name="language" value="CA">CA (Canada)</option>
+              <option name="language" value="CB">CB (Cambodia)</option>
+              <option name="language" value="CD">CD (Chad)</option>
+              <option name="language" value="CE">CE (Sri Lanka)</option>
+              <option name="language" value="CF">CF (Congo (Brazzaville))</option>
+              <option name="language" value="CG">CG (Congo (Kinshasa))</option>
+              <option name="language" value="CH">CH (China)</option>
+              <option name="language" value="CI">CI (Chile)</option>
+              <option name="language" value="CJ">CJ (Cayman Islands)</option>
+              <option name="language" value="CK">CK (Cocos (Keeling) Islands)</option>
+              <option name="language" value="CM">CM (Cameroon)</option>
+              <option name="language" value="CN">CN (Comoros)</option>
+              <option name="language" value="CO">CO (Colombia)</option>
+              <option name="language" value="CQ">CQ (Northern Mariana Islands)</option>
+              <option name="language" value="CR">CR (Coral Sea Islands)</option>
+              <option name="language" value="CS">CS (Costa Rica)</option>
+              <option name="language" value="CT">CT (Central African Republic)</option>
+              <option name="language" value="CU">CU (Cuba)</option>
+              <option name="language" value="CV">CV (Cape Verde)</option>
+              <option name="language" value="CW">CW (Cook Islands)</option>
+              <option name="language" value="CY">CY (Cyprus)</option>
+              <option name="language" value="DK">DK (Denmark)</option>
+              <option name="language" value="DJ">DJ (Djibouti)</option>
+              <option name="language" value="DO">DO (Dominica)</option>
+              <option name="language" value="DQ">DQ (Jarvis Island)</option>
+              <option name="language" value="DR">DR (Dominican Republic)</option>
+              <option name="language" value="DX">DX (Dhekelia)</option>
+              <option name="language" value="EC">EC (Ecuador)</option>
+              <option name="language" value="EG">EG (Egypt)</option>
+              <option name="language" value="EI">EI (Ireland)</option>
+              <option name="language" value="EK">EK (Equatorial Guinea)</option>
+              <option name="language" value="EN">EN (Estonia)</option>
+              <option name="language" value="ER">ER (Eritrea)</option>
+              <option name="language" value="ES">ES (El Salvador)</option>
+              <option name="language" value="ET">ET (Ethiopia)</option>
+              <option name="language" value="EU">EU (Europa Island)</option>
+              <option name="language" value="EZ">EZ (Czech Republic)</option>
+              <option name="language" value="FG">FG (French Guiana)</option>
+              <option name="language" value="FI">FI (Finland)</option>
+              <option name="language" value="FJ">FJ (Fiji)</option>
+              <option name="language" value="FK">FK (Falkland Islands (Islas Malvinas))</option>
+              <option name="language" value="FM">FM (Micronesia, Federated States of)</option>
+              <option name="language" value="FO">FO (Faroe Islands)</option>
+              <option name="language" value="FP">FP (French Polynesia)</option>
+              <option name="language" value="FQ">FQ (Baker Island)</option>
+              <option name="language" value="FR">FR (France)</option>
+              <option name="language" value="FS">FS (French Southern and Antarctic Lands)</option>
+              <option name="language" value="GA">GA (Gambia, The)</option>
+              <option name="language" value="GB">GB (Gabon)</option>
+              <option name="language" value="GG">GG (Georgia)</option>
+              <option name="language" value="GH">GH (Ghana)</option>
+              <option name="language" value="GI">GI (Gibraltar)</option>
+              <option name="language" value="GJ">GJ (Grenada)</option>
+              <option name="language" value="GK">GK (Guernsey)</option>
+              <option name="language" value="GL">GL (Greenland)</option>
+              <option name="language" value="GM">GM (Germany)</option>
+              <option name="language" value="GO">GO (Glorioso Islands)</option>
+              <option name="language" value="GP">GP (Guadeloupe)</option>
+              <option name="language" value="GQ">GQ (Guam)</option>
+              <option name="language" value="GR">GR (Greece)</option>
+              <option name="language" value="GT">GT (Guatemala)</option>
+              <option name="language" value="GV">GV (Guinea)</option>
+              <option name="language" value="GY">GY (Guyana)</option>
+              <option name="language" value="GZ">GZ (Gaza Strip)</option>
+              <option name="language" value="HA">HA (Haiti)</option>
+              <option name="language" value="HK">HK (Hong Kong)</option>
+              <option name="language" value="HM">HM (Heard Island and McDonald Islands)</option>
+              <option name="language" value="HO">HO (Honduras)</option>
+              <option name="language" value="HQ">HQ (Howland Island)</option>
+              <option name="language" value="HR">HR (Croatia)</option>
+              <option name="language" value="HU">HU (Hungary)</option>
+              <option name="language" value="IC">IC (Iceland)</option>
+              <option name="language" value="ID">ID (Indonesia)</option>
+              <option name="language" value="IM">IM (Isle of Man)</option>
+              <option name="language" value="IN">IN (India)</option>
+              <option name="language" value="IO">IO (British Indian Ocean Territory)</option>
+              <option name="language" value="IP">IP (Clipperton Island)</option>
+              <option name="language" value="IR">IR (Iran)</option>
+              <option name="language" value="IS">IS (Israel)</option>
+              <option name="language" value="IT">IT (Italy)</option>
+              <option name="language" value="IV">IV (Côte d'Ivoire)</option>
+              <option name="language" value="IZ">IZ (Iraq)</option>
+              <option name="language" value="JA">JA (Japan)</option>
+              <option name="language" value="JE">JE (Jersey)</option>
+              <option name="language" value="JM">JM (Jamaica)</option>
+              <option name="language" value="JN">JN (Jan Mayen)</option>
+              <option name="language" value="JO">JO (Jordan)</option>
+              <option name="language" value="JQ">JQ (Johnston Atoll)</option>
+              <option name="language" value="JU">JU (Juan de Nova Island)</option>
+              <option name="language" value="KE">KE (Kenya)</option>
+              <option name="language" value="KG">KG (Kyrgyzstan)</option>
+              <option name="language" value="KN">KN (Korea, North)</option>
+              <option name="language" value="KQ">KQ (Kingman Reef)</option>
+              <option name="language" value="KR">KR (Kiribati)</option>
+              <option name="language" value="KS">KS (Korea, South)</option>
+              <option name="language" value="KT">KT (Christmas Island)</option>
+              <option name="language" value="KU">KU (Kuwait)</option>
+              <option name="language" value="KV">KV (Kosovo)</option>
+              <option name="language" value="KZ">KZ (Kazakhstan)</option>
+              <option name="language" value="LA">LA (Laos)</option>
+              <option name="language" value="LE">LE (Lebanon)</option>
+              <option name="language" value="LG">LG (Latvia)</option>
+              <option name="language" value="LH">LH (Lithuania)</option>
+              <option name="language" value="LI">LI (Liberia)</option>
+              <option name="language" value="LO">LO (Slovakia)</option>
+              <option name="language" value="LQ">LQ (Palmyra Atoll)</option>
+              <option name="language" value="LS">LS (Liechtenstein)</option>
+              <option name="language" value="LT">LT (Lesotho)</option>
+              <option name="language" value="LU">LU (Luxembourg)</option>
+              <option name="language" value="LY">LY (Libya)</option>
+              <option name="language" value="MA">MA (Madagascar)</option>
+              <option name="language" value="MB">MB (Martinique)</option>
+              <option name="language" value="MC">MC (Macau)</option>
+              <option name="language" value="MD">MD (Moldova)</option>
+              <option name="language" value="MF">MF (Mayotte)</option>
+              <option name="language" value="MG">MG (Mongolia)</option>
+              <option name="language" value="MH">MH (Montserrat)</option>
+              <option name="language" value="MI">MI (Malawi)</option>
+              KEEPNAME:Montenegro
+              <option name="language" value="MK">MK (Macedonia)</option>
+              <option name="language" value="ML">ML (Mali)</option>
+              <option name="language" value="MN">MN (Monaco)</option>
+              <option name="language" value="MO">MO (Morocco)</option>
+              <option name="language" value="MP">MP (Mauritius)</option>
+              <option name="language" value="MQ">MQ (Midway Islands)</option>
+              <option name="language" value="MR">MR (Mauritania)</option>
+              <option name="language" value="MT">MT (Malta)</option>
+              <option name="language" value="MU">MU (Oman)</option>
+              <option name="language" value="MV">MV (Maldives)</option>
+              <option name="language" value="MX">MX (Mexico)</option>
+              <option name="language" value="MY">MY (Malaysia)</option>
+              <option name="language" value="MZ">MZ (Mozambique)</option>
+              <option name="language" value="NC">NC (New Caledonia)</option>
+              <option name="language" value="NE">NE (Niue)</option>
+              <option name="language" value="NF">NF (Norfolk Island)</option>
+              <option name="language" value="NG">NG (Niger)</option>
+              <option name="language" value="NH">NH (Vanuatu)</option>
+              <option name="language" value="NI">NI (Nigeria)</option>
+              <option name="language" value="NL">NL (Netherlands)</option>
+              <option name="language" value="NN">NN (Sint Maarten)</option>
+              <option name="language" value="NO">NO (Norway)</option>
+              <option name="language" value="NP">NP (Nepal)</option>
+              <option name="language" value="NR">NR (Nauru)</option>
+              <option name="language" value="NS">NS (Suriname)</option>
+              <option name="language" value="NU">NU (Nicaragua)</option>
+              <option name="language" value="NZ">NZ (New Zealand)</option>
+              <option name="language" value="OD">OD (South Sudan)</option>
+              <option name="language" value="PA">PA (Paraguay)</option>
+              <option name="language" value="PC">PC (Pitcairn Islands)</option>
+              <option name="language" value="PE">PE (Peru)</option>
+              <option name="language" value="PF">PF (Paracel Islands)</option>
+              <option name="language" value="PG">PG (Spratly Islands)</option>
+              <option name="language" value="PJ">PJ (Etorofu, Habomai, Kunashiri, and Shikotan Islands)</option>
+              <option name="language" value="PK">PK (Pakistan)</option>
+              <option name="language" value="PL">PL (Poland)</option>
+              <option name="language" value="PM">PM (Panama)</option>
+              <option name="language" value="PO">PO (Portugal)</option>
+              <option name="language" value="PP">PP (Papua New Guinea)</option>
+              <option name="language" value="PS">PS (Palau)</option>
+              <option name="language" value="PU">PU (Guinea-Bissau)</option>
+              <option name="language" value="QA">QA (Qatar)</option>
+              <option name="language" value="RE">RE (Réunion)</option>
+              <option name="language" value="RI">RI (Serbia)</option>
+              <option name="language" value="RM">RM (Marshall Islands)</option>
+              <option name="language" value="RN">RN (Saint Martin)</option>
+              <option name="language" value="RO">RO (Romania)</option>
+              <option name="language" value="RP">RP (Philippines)</option>
+              <option name="language" value="RQ">RQ (Puerto Rico)</option>
+              <option name="language" value="RS">RS (Russia)</option>
+              <option name="language" value="RW">RW (Rwanda)</option>
+              <option name="language" value="SA">SA (Saudi Arabia)</option>
+              <option name="language" value="SB">SB (Saint Pierre and Miquelon)</option>
+              <option name="language" value="SC">SC (Saint Kitts and Nevis)</option>
+              <option name="language" value="SE">SE (Seychelles)</option>
+              <option name="language" value="SF">SF (South Africa)</option>
+              <option name="language" value="SG">SG (Senegal)</option>
+              <option name="language" value="SH">SH (Saint Helena, Ascension, and Tristan da Cunha)</option>
+              <option name="language" value="SI">SI (Slovenia)</option>
+              <option name="language" value="SL">SL (Sierra Leone)</option>
+              <option name="language" value="SM">SM (San Marino)</option>
+              <option name="language" value="SN">SN (Singapore)</option>
+              <option name="language" value="SO">SO (Somalia)</option>
+              <option name="language" value="SP">SP (Spain)</option>
+              <option name="language" value="ST">ST (Saint Lucia)</option>
+              <option name="language" value="SU">SU (Sudan)</option>
+              <option name="language" value="SV">SV (Svalbard)</option>
+              <option name="language" value="SW">SW (Sweden)</option>
+              <option name="language" value="SX">SX (South Georgia and South Sandwich Islands)</option>
+              <option name="language" value="SY">SY (Syria)</option>
+              <option name="language" value="SZ">SZ (Switzerland)</option>
+              <option name="language" value="TB">TB (Saint Barthelemy)</option>
+              <option name="language" value="TD">TD (Trinidad and Tobago)</option>
+              <option name="language" value="TE">TE (Tromelin Island)</option>
+              <option name="language" value="TH">TH (Thailand)</option>
+              <option name="language" value="TI">TI (Tajikistan)</option>
+              <option name="language" value="TK">TK (Turks and Caicos Islands)</option>
+              <option name="language" value="TL">TL (Tokelau)</option>
+              <option name="language" value="TN">TN (Tonga)</option>
+              <option name="language" value="TO">TO (Togo)</option>
+              <option name="language" value="TP">TP (Sao Tome and Principe)</option>
+              <option name="language" value="TS">TS (Tunisia)</option>
+              <option name="language" value="TT">TT (Timor-Leste)</option>
+              <option name="language" value="TU">TU (Turkey)</option>
+              <option name="language" value="TV">TV (Tuvalu)</option>
+              <option name="language" value="TW">TW (Taiwan)</option>
+              <option name="language" value="TX">TX (Turkmenistan)</option>
+              <option name="language" value="TZ">TZ (Tanzania)</option>
+              <option name="language" value="UA">UA (Ukraine)</option>
+              <option name="language" value="UC">UC (Curaçao)</option>
+              <option name="language" value="UG">UG (Uganda)</option>
+              <option name="language" value="UK">UK (United Kingdom)</option>
+              <option name="language" value="US">US (United States)</option>
+              <option name="language" value="UV">UV (Burkina Faso)</option>
+              <option name="language" value="UY">UY (Uruguay)</option>
+              <option name="language" value="UZ">UZ (Uzbekistan)</option>
+              <option name="language" value="VC">VC (Saint Vincent and the Grenadines)</option>
+              <option name="language" value="VE">VE (Venezuela)</option>
+              <option name="language" value="VI">VI (British Virgin Islands)</option>
+              <option name="language" value="VN">VN (Vietnam)</option>
+              <option name="language" value="VQ">VQ (United States Virgin Islands)</option>
+              <option name="language" value="VT">VT (Vatican City)</option>
+              <option name="language" value="WA">WA (Namibia)</option>
+              <option name="language" value="WE">WE (West Bank)</option>
+              <option name="language" value="WF">WF (Wallis and Futuna)</option>
+              <option name="language" value="WQ">WQ (Wake Island)</option>
+              <option name="language" value="WS">WS (Samoa)</option>
+              <option name="language" value="WZ">WZ (Swaziland)</option>
+              <option name="language" value="YM">YM (Yemen)</option>
+              <option name="language" value="ZA">ZA (Zambia)</option>
+              <option name="language" value="ZI">ZI (Zimbabwe)</option>
             </select>
 
           </div>

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -20,42 +20,43 @@
       <!--<form id="searchForm" method="get" action="PUBLIC_API_URI/api/v1/citations/">-->
       <form id="searchForm" method="get" action="http://54.229.175.46:8081/api/v1/citations/">
 
-      <input class="text-input" type="search" name="search" placeholder="10.nnnn.nn formatted search">
-        <button class="button" type="submit">Search</button>
-
-
-        <fieldset class="id-type-wrapper">
-          <legend>Which type of identifier are you searching with? </legend>
-
-          <div class="multi-choice-item"><input type="radio" name="type" value="doi" id="idPickerDOI" checked/><label for="idPickerDOI">DOI</label></div>
-          <div class="multi-choice-item"><input type="radio" name="type" value="isbn" id="idPickerISBN" /><label for="idPickerISBN">ISBN</label></div>
-          <div class="multi-choice-item"><input type="radio" name="type" value="arxiv" id="idPickerARXIV" /><label for="idPickerARXIV">ARXIV</label></div>
-          <div class="multi-choice-item"><input type="radio" name="type" value="pmid" id="idPickerPMID" /><label for="idPickerPMID">PubMed ID</label></div>
-          <div class="multi-choice-item"><input type="radio" name="type" value="pmcid" id="idPickerPMCID" /><label for="idPickerPMCID">PubMed Central ID</label></div>
-
-        </fieldset>
-
-
-        <div class="lang-picker-wrapper">
-          <label for="langPicker">Choose a language (by default searches across all languages)</label>
-
-        <select name="language" id="langPicker" class="lang-picker">
-          <option name="language" value="" selected>All</option>
-          <option name="language" value="en">English</option>
-          <option name="language" value="de">German</option>
-          <option name="language" value="es">Spanish</option>
-          <option name="language">...</option>
-
-        </select>
-
+        <div class="search-text-and-go">
+          <input class="text-input" type="search" name="search" placeholder="10.nnnn.nn formatted search" />
+          <button class="button" type="submit">Search</button>
         </div>
 
+        <div class="pickers">
+          <fieldset class="id-type-wrapper">
+            <legend>Which type of identifier are you searching with? </legend>
 
-        <fieldset class="date-picker">
-          <legend>Pick a date range</legend>
-          <div><label for="datePickerStart">Choose a start date</label>: <input type="date" id="datePickerStart"  name="startDate"></div>
-          <div><label for="datePickerEnd">Choose an end date</label>: <input type="date" name="endDate" id="datePickerEnd"></div>
-        </fieldset>
+            <div class="multi-choice-item"><input type="radio" name="type" value="doi" id="idPickerDOI" checked/><label for="idPickerDOI">DOI</label></div>
+            <div class="multi-choice-item"><input type="radio" name="type" value="isbn" id="idPickerISBN" /><label for="idPickerISBN">ISBN</label></div>
+            <div class="multi-choice-item"><input type="radio" name="type" value="arxiv" id="idPickerARXIV" /><label for="idPickerARXIV">ARXIV</label></div>
+            <div class="multi-choice-item"><input type="radio" name="type" value="pmid" id="idPickerPMID" /><label for="idPickerPMID">PubMed ID</label></div>
+            <div class="multi-choice-item"><input type="radio" name="type" value="pmcid" id="idPickerPMCID" /><label for="idPickerPMCID">PubMed Central ID</label></div>
+
+          </fieldset>
+
+          <div class="lang-picker-wrapper">
+            <label for="langPicker">Choose a language (by default searches across all languages)</label>
+
+            <select name="language" id="langPicker" class="lang-picker">
+              <option name="language" value="" selected>All</option>
+              <option name="language" value="en">English</option>
+              <option name="language" value="de">German</option>
+              <option name="language" value="es">Spanish</option>
+              <option name="language">...</option>
+
+            </select>
+
+          </div>
+
+          <fieldset class="date-picker">
+            <legend>Pick a date range</legend>
+            <div><label for="datePickerStart">Choose a start date</label>: <input type="date" id="datePickerStart"  name="startDate"></div>
+            <div><label for="datePickerEnd">Choose an end date</label>: <input type="date" name="endDate" id="datePickerEnd"></div>
+          </fieldset>
+        </div>
 
       </form>
 

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -11,9 +11,9 @@
 
   <main>
 
-    <header class=page-header">
-      <h1 class=page-header__heading">WikiCiteVis</h1>
-      <p class=page-header__stand_first">WikiCiteVis is a tool to search and visualise Wikipedia's citation data, using the <a href="https://figshare.com/articles/Wikipedia_Scholarly_Article_Citations/1299540">Citations with identifiers in Wikipedia</a> dataset.</p>
+    <header class="page-header">
+      <h1 class="page-header__heading">WikiCiteVis</h1>
+      <p class="page-header__stand_first">WikiCiteVis is a tool to search and visualise Wikipedia's citation data, using the <a href="https://figshare.com/articles/Wikipedia_Scholarly_Article_Citations/1299540">Citations with identifiers in Wikipedia</a> dataset.</p>
       <p>The data only contains identifiers present on March 1, 2018, so any added since then will not be present in this tool. Approximately 98% of identifiers resolve, which may mean you come across identifiers in this tool that aren't valid.</p>
     </header>
 

--- a/client/src/js/DOMBuilder.js
+++ b/client/src/js/DOMBuilder.js
@@ -74,21 +74,24 @@ module.exports = class DOMBuilder {
   static constructHeadColHeading(text, propertyName, $form) {
     const $th = DOMBuilder.buildElement('th', ['search-results__item__heading']);
     const $button = DOMBuilder.buildElement('button', ['ordering-control'], text, $th);
-
     $button.addEventListener('click', () => {
-      // remove any previous orderBy fields
-      const oldFields = $form.querySelectorAll('[name="orderBy"]');
-      if (oldFields) {
-        [].forEach.call(oldFields, (oldField) => {
-          $form.removeChild(oldField);
-        });
+
+      let newOrderByValue = propertyName;
+      // handle a previous orderBy field
+      const oldField = $form.querySelector('[name="orderBy"]');
+      // if the inverse of the same field appears invert it again (handles asc -> desc & visa versa)
+      if (oldField) {
+        if (oldField.value === propertyName) {
+          newOrderByValue = `-${propertyName}`
+        }
+        $form.removeChild(oldField);
       }
 
       // create hidden orderBy field
       const $orderBy = DOMBuilder.buildElement('input', [], '', $form);
       $orderBy.name = 'orderBy';
       $orderBy.type = 'hidden';
-      $orderBy.value = propertyName;
+      $orderBy.value = newOrderByValue;
       $form.appendChild($orderBy);
       // click on form submit button
       $form.querySelector('[type="submit"]').click();
@@ -207,6 +210,19 @@ module.exports = class DOMBuilder {
     }
 
     document.querySelector('.search-results').appendChild($pager);
+  }
+
+  static constructOrderToggle(isDescending) {
+
+    const toggle = () => {
+
+    }
+
+    const text = isDescending ? 'descending' : 'acending';
+    const $toggle = this.buildElement('button', [], text);
+    $toggle
+
+    return toggle;
   }
 
 };

--- a/client/src/js/DOMBuilder.js
+++ b/client/src/js/DOMBuilder.js
@@ -166,7 +166,7 @@ module.exports = class DOMBuilder {
     $element.innerHTML = '';
   }
 
-  static constructPager(uris, getData, displayData) {
+  static constructPager(uris, getData, displayData, $searchResultsContainer) {
     const $oldPager = document.querySelector('.pager');
     if ($oldPager) {
       $oldPager.parentNode.removeChild($oldPager);
@@ -179,6 +179,7 @@ module.exports = class DOMBuilder {
       // Temporary hacking the URL to get a local client instance running
       $next.dataset.uri = uris.next.replace('http://api:8000', 'http://54.229.175.46:8081');
       $next.addEventListener('click', (e) => {
+        DOMBuilder.constructLoadingSpinner($searchResultsContainer);
         getData.call(null, e.target.dataset.uri).then(displayData).then(DOMBuilder.removeLoadingSpinner);
       });
       $pager.appendChild($next);

--- a/client/src/js/DOMBuilder.js
+++ b/client/src/js/DOMBuilder.js
@@ -71,27 +71,48 @@ module.exports = class DOMBuilder {
     return $el;
   }
 
-  static constructHeadColHeading(text, href) {
+  static constructHeadColHeading(text, propertyName, $form) {
     const $th = DOMBuilder.buildElement('th', ['search-results__item__heading']);
-    const $a = DOMBuilder.buildElement('a', [], text, $th);
-    $a.href = href;
+    const $button = DOMBuilder.buildElement('button', ['ordering-control'], text, $th);
+
+    $button.addEventListener('click', () => {
+      // remove any previous orderBy fields
+      const oldFields = $form.querySelectorAll('[name="orderBy"]');
+      if (oldFields) {
+        [].forEach.call(oldFields, (oldField) => {
+          $form.removeChild(oldField);
+        });
+      }
+
+      // create hidden orderBy field
+      const $orderBy = DOMBuilder.buildElement('input', [], '', $form);
+      $orderBy.name = 'orderBy';
+      $orderBy.type = 'hidden';
+      $orderBy.value = propertyName;
+      $form.appendChild($orderBy);
+      // click on form submit button
+      $form.querySelector('[type="submit"]').click();
+    });
+
+
+
     return $th;
   }
 
-  static constructTableHead(headRowCols) {
+  static constructTableHead(headRowCols, $form) {
     const $thead = DOMBuilder.buildElement('thead');
     const $headRow = DOMBuilder.buildElement('tr', ['search-results__row'], '', $thead);
 
     headRowCols.forEach((colData) => {
-      $headRow.appendChild(DOMBuilder.constructHeadColHeading(colData.text, colData.href));
+      $headRow.appendChild(DOMBuilder.constructHeadColHeading(colData.text, colData.properyName, $form));
     });
 
     return $thead;
   }
 
-  static constructTableSkeleton(headRowCols) {
+  static constructTableSkeleton(headRowCols, $form) {
     const $table = DOMBuilder.buildElement('table');
-    const $thead = DOMBuilder.constructTableHead(headRowCols);
+    const $thead = DOMBuilder.constructTableHead(headRowCols, $form);
     $table.appendChild($thead);
     return $table;
   }
@@ -119,8 +140,8 @@ module.exports = class DOMBuilder {
     return $tr;
   }
 
-  static constructResultsTable(list, headRowCols, deriveSourceUri) {
-    const $table = DOMBuilder.constructTableSkeleton(headRowCols);
+  static constructResultsTable(list, headRowCols, deriveSourceUri, $form) {
+    const $table = DOMBuilder.constructTableSkeleton(headRowCols, $form);
     let $tbody = DOMBuilder.buildElement('tbody');
     DOMBuilder.appendToTableBody(list, deriveSourceUri, $tbody);
     $table.appendChild($tbody);

--- a/client/src/js/DOMBuilder.js
+++ b/client/src/js/DOMBuilder.js
@@ -137,15 +137,27 @@ module.exports = class DOMBuilder {
   }
 
   static constructResultsHeading(resultCount) {
-    const countDisplay = ` (${resultCount} results)`;
-    const $heading = document.getElementById('searchResultsHeading');
+    const $container = document.querySelector('.search-results');
+    let $heading = $container.querySelector('.heading');
+    if (!$heading) {
+      $heading = DOMBuilder.buildElement('h2', ['heading'], 'Search results', $container);
+    }
+
     let $count = $heading.querySelector('.result-count');
+    const countDisplay = ` (${resultCount} results)`;
     if (!$count) {
       $count = DOMBuilder.buildElement('span', ['result-count'], countDisplay, $heading);
     } else {
       $count.innerHTML = countDisplay;
     }
-    $heading.appendChild($count);
   }
 
-}
+  static constructLoadingSpinner($parent) {
+    DOMBuilder.buildElement('div', ['loading-spinner'], '', $parent);
+  }
+
+  static removeLoadingSpinner() {
+    document.querySelector('.loading-spinner').parentNode.removeChild(document.querySelector('.loading-spinner'));
+  }
+
+};

--- a/client/src/js/DOMBuilder.js
+++ b/client/src/js/DOMBuilder.js
@@ -129,7 +129,7 @@ module.exports = class DOMBuilder {
     const $tdTitleLink = DOMBuilder.buildElement('a', ['search-results__item__lang'], data.page_title, $tdTitle);
     $tdTitleLink.href = `https://${data.language}.wikipedia.org/wiki/${processedTitle}`;
 
-    const $topic = DOMBuilder.buildElement('td', [], data.article_topic);
+    const $topic = DOMBuilder.buildElement('td', [], data.article_topic.replace(/_/g, ' '));
 
     const $oaStatus = DOMBuilder.buildElement('td');
     const oaUrl = data.oa_url;

--- a/client/src/js/DOMBuilder.js
+++ b/client/src/js/DOMBuilder.js
@@ -189,13 +189,17 @@ module.exports = class DOMBuilder {
   }
 
   static constructLoadingSpinner($parent) {
-    DOMBuilder.buildElement('div', ['loading-spinner'], '', $parent);
+    $parent.classList.add('loading');
+    const $wrapper = DOMBuilder.buildElement('div', ['loading-spinner-wrapper'], '', $parent);
+    DOMBuilder.buildElement('div', ['loading-spinner'], '', $wrapper);
   }
 
   static removeLoadingSpinner() {
-    const $loadingSpinner = document.querySelector('.loading-spinner');
-    if ($loadingSpinner) {
-      $loadingSpinner.parentNode.removeChild(document.querySelector('.loading-spinner'));
+    const $loadingSpinnerWrapper = document.querySelector('.loading-spinner-wrapper');
+    if ($loadingSpinnerWrapper) {
+      const $parent = $loadingSpinnerWrapper.parentNode;
+      $parent.removeChild($loadingSpinnerWrapper);
+      $parent.classList.remove('loading');
     }
   }
 

--- a/client/src/js/DOMBuilder.js
+++ b/client/src/js/DOMBuilder.js
@@ -144,7 +144,10 @@ module.exports = class DOMBuilder {
     const sourceUri = deriveSourceUri.call(null, data.id, data.type);
     const $sourceLink = DOMBuilder.buildElement('a', [], data.page_id, $tdId);
     $sourceLink.href = sourceUri;
-    const $timeStamp = DOMBuilder.buildElement('td', ['search-results__item__time'], data.timestamp);
+
+    const $timeStamp = DOMBuilder.buildElement('td', ['search-results__item__time']);
+    const $diffLink = DOMBuilder.buildElement('a', [], data.timestamp, $timeStamp);
+    $diffLink.href = `https://${data.language}.wikipedia.org/wiki/Special:Diff/${data.rev_id}`;
 
     $tr.appendChild($tdLang);
     $tr.appendChild($tdTitle);

--- a/client/src/js/DOMBuilder.js
+++ b/client/src/js/DOMBuilder.js
@@ -129,6 +129,15 @@ module.exports = class DOMBuilder {
     const $tdTitleLink = DOMBuilder.buildElement('a', ['search-results__item__lang'], data.page_title, $tdTitle);
     $tdTitleLink.href = `https://${data.language}.wikipedia.org/wiki/${processedTitle}`;
 
+    const $topic = DOMBuilder.buildElement('td', [], data.article_topic);
+
+    const $oaStatus = DOMBuilder.buildElement('td');
+    const oaUrl = data.oa_url;
+    if (oaUrl) {
+      const $link = DOMBuilder.buildElement('a', [], data.oa_status, $oaStatus);
+      $link.href = data.oa_url;
+    }
+
     const $tdId = DOMBuilder.buildElement('td', ['search-results__item__id']);
     const sourceUri = deriveSourceUri.call(null, data.page_id, data.type);
     const $sourceLink = DOMBuilder.buildElement('a', [], data.page_id, $tdId);
@@ -137,6 +146,8 @@ module.exports = class DOMBuilder {
 
     $tr.appendChild($tdLang);
     $tr.appendChild($tdTitle);
+    $tr.appendChild($topic);
+    $tr.appendChild($oaStatus);
     $tr.appendChild($tdId);
     $tr.appendChild($timeStamp);
 

--- a/client/src/js/DOMBuilder.js
+++ b/client/src/js/DOMBuilder.js
@@ -141,7 +141,7 @@ module.exports = class DOMBuilder {
     }
 
     const $tdId = DOMBuilder.buildElement('td', ['search-results__item__id']);
-    const sourceUri = deriveSourceUri.call(null, data.page_id, data.type);
+    const sourceUri = deriveSourceUri.call(null, data.id, data.type);
     const $sourceLink = DOMBuilder.buildElement('a', [], data.page_id, $tdId);
     $sourceLink.href = sourceUri;
     const $timeStamp = DOMBuilder.buildElement('td', ['search-results__item__time'], data.timestamp);

--- a/client/src/js/DOMBuilder.js
+++ b/client/src/js/DOMBuilder.js
@@ -140,11 +140,11 @@ module.exports = class DOMBuilder {
     const $container = document.querySelector('.search-results');
     let $heading = $container.querySelector('.heading');
     if (!$heading) {
-      $heading = DOMBuilder.buildElement('h2', ['heading'], 'Search results', $container);
+      $heading = DOMBuilder.buildElement('h2', ['heading'], '', $container);
     }
 
     let $count = $heading.querySelector('.result-count');
-    const countDisplay = ` (${resultCount} results)`;
+    const countDisplay = ` ${resultCount} results`;
     if (!$count) {
       $count = DOMBuilder.buildElement('span', ['result-count'], countDisplay, $heading);
     } else {
@@ -158,6 +158,10 @@ module.exports = class DOMBuilder {
 
   static removeLoadingSpinner() {
     document.querySelector('.loading-spinner').parentNode.removeChild(document.querySelector('.loading-spinner'));
+  }
+
+  static clear($element) {
+    $element.innerHTML = '';
   }
 
 };

--- a/client/src/js/DOMBuilder.js
+++ b/client/src/js/DOMBuilder.js
@@ -133,6 +133,7 @@ module.exports = class DOMBuilder {
 
     const $oaStatus = DOMBuilder.buildElement('td');
     const oaUrl = data.oa_url;
+    // 'nan' seems to be junk data so don't try and link to it (still display, to expose in case needs fixing).
     if (oaUrl && oaUrl.toLowerCase() !== 'nan') {
       const $link = DOMBuilder.buildElement('a', [], data.oa_status, $oaStatus);
       $link.href = data.oa_url;

--- a/client/src/js/DOMBuilder.js
+++ b/client/src/js/DOMBuilder.js
@@ -133,9 +133,11 @@ module.exports = class DOMBuilder {
 
     const $oaStatus = DOMBuilder.buildElement('td');
     const oaUrl = data.oa_url;
-    if (oaUrl) {
+    if (oaUrl && oaUrl.toLowerCase() !== 'nan') {
       const $link = DOMBuilder.buildElement('a', [], data.oa_status, $oaStatus);
       $link.href = data.oa_url;
+    } else {
+      $oaStatus.innerHTML = data.oa_status;
     }
 
     const $tdId = DOMBuilder.buildElement('td', ['search-results__item__id']);

--- a/client/src/js/main.js
+++ b/client/src/js/main.js
@@ -42,14 +42,18 @@ const DOMBuilder = require('./DOMBuilder');
     console.log('data', dataString);
     const data = JSON.parse(dataString);
     DOMBuilder.constructResultsHeading(data.count);
-    DOMBuilder.constructResultsTable(data.results, config.headRowCols, deriveSourceUri);
+    if (data.count) {
+      DOMBuilder.constructResultsTable(data.results, config.headRowCols, deriveSourceUri);
+    }
 
   }
 
   function handleSubmit(e) {
     e.preventDefault();
     e.stopPropagation();
-    DOMBuilder.constructLoadingSpinner(document.querySelector('.search-results'));
+    const $searchResultsContainer = document.querySelector('.search-results');
+    DOMBuilder.clear($searchResultsContainer);
+    DOMBuilder.constructLoadingSpinner($searchResultsContainer);
     getData(composeQuery(e.target))
       .then(displayData).then(DOMBuilder.removeLoadingSpinner);
     console.log('query:' ,composeQuery(e.target));

--- a/client/src/js/main.js
+++ b/client/src/js/main.js
@@ -6,15 +6,33 @@ const DOMBuilder = require('./DOMBuilder');
 
   const $searchForm = document.getElementById('searchForm');
 
+  function getDateString(theDate) {
+    // month is 0 indexed
+    let month = theDate.getMonth() + 1;
+    if (month < 10) {
+      month = '0' + month;
+    }
+    let date = theDate.getDate() < 10 ? `0${theDate.getDate()}` : theDate.getDate();
+    return `${theDate.getFullYear()}-${month}-${date}`;
+  }
+
   function composeQuery($form) {
     // return 'http://54.229.175.46:8081/api/v1/citations/?id=10.7554/eLife.09560';
 
     const baseUri = $form.action;
     const term = $form.search.value;
     const type = $form.querySelector('input[name="type"]:checked').value;
-    const startDate = $form.startDate.value;
-    // TODO: Add now as end date if none specified
-    const endDate = $form.endDate.value;
+
+    // Add dates if none specified
+    let startDate = $form.startDate.value;
+    if (!startDate.length) {
+      startDate = getDateString(new Date('01-01-2010'));
+    }
+
+    let endDate = $form.endDate.value;
+    if (!endDate.length) {
+      endDate = getDateString(new Date());
+    }
 
     const $langPicker = $form.querySelector('#langPicker');
     const language = $langPicker.options[$langPicker.selectedIndex].value;

--- a/client/src/js/main.js
+++ b/client/src/js/main.js
@@ -7,6 +7,8 @@ const DOMBuilder = require('./DOMBuilder');
   const $searchForm = document.getElementById('searchForm');
 
   function composeQuery($form) {
+    // return 'http://54.229.175.46:8081/api/v1/citations/?id=10.7554/eLife.09560';
+
     const baseUri = $form.action;
     const search = $form.search.value;
     const type = $form.querySelector('input[name="type"]:checked').value;
@@ -35,9 +37,13 @@ const DOMBuilder = require('./DOMBuilder');
     );
   }
 
-  function displayData(data) {
+  function displayData(dataString) {
     console.log('Placeholder fn until search returning results');
-    console.log('data', data);
+    console.log('data', dataString);
+    const data = JSON.parse(dataString);
+    DOMBuilder.constructResultsHeading(data);
+    DOMBuilder.constructResultsTable(data.results, config.headRowCols, deriveSourceUri);
+
   }
 
   function handleSubmit(e) {
@@ -150,9 +156,5 @@ const DOMBuilder = require('./DOMBuilder');
   };
 
   $searchForm.addEventListener('submit', handleSubmit);
-
-  // TODO: Move next 2 lines to the displayData function (the promise resolution callback)
-  DOMBuilder.constructResultsHeading(mockData.count);
-  DOMBuilder.constructResultsTable(mockData.results, config.headRowCols, deriveSourceUri);
 
 }(window));

--- a/client/src/js/main.js
+++ b/client/src/js/main.js
@@ -38,8 +38,6 @@ const DOMBuilder = require('./DOMBuilder');
   }
 
   function displayData(dataString) {
-    console.log('Placeholder fn until search returning results');
-    console.log('data', dataString);
     const data = JSON.parse(dataString);
 
     if (!data.count) {
@@ -60,7 +58,8 @@ const DOMBuilder = require('./DOMBuilder');
         next: data.next
       },
       getData,
-      displayData
+      displayData,
+      document.querySelector('.search-results')
       );
   }
 

--- a/client/src/js/main.js
+++ b/client/src/js/main.js
@@ -13,6 +13,7 @@ const DOMBuilder = require('./DOMBuilder');
     const term = $form.search.value;
     const type = $form.querySelector('input[name="type"]:checked').value;
     const startDate = $form.startDate.value;
+    // TODO: Add now as end date if none specified
     const endDate = $form.endDate.value;
 
     const $langPicker = $form.querySelector('#langPicker');

--- a/client/src/js/main.js
+++ b/client/src/js/main.js
@@ -10,7 +10,7 @@ const DOMBuilder = require('./DOMBuilder');
     // return 'http://54.229.175.46:8081/api/v1/citations/?id=10.7554/eLife.09560';
 
     const baseUri = $form.action;
-    const search = $form.search.value;
+    const term = $form.search.value;
     const type = $form.querySelector('input[name="type"]:checked').value;
     const startDate = $form.startDate.value;
     const endDate = $form.endDate.value;
@@ -18,7 +18,10 @@ const DOMBuilder = require('./DOMBuilder');
     const $langPicker = $form.querySelector('#langPicker');
     const language = $langPicker.options[$langPicker.selectedIndex].value;
 
-    return `${baseUri}?search=${search}&type=${type}&language=${language}&startDate=${startDate}&endDate=${endDate}`;
+    const isIdLookup = $form.querySelector('#stringency').checked;
+    const stringency = isIdLookup ? 'id' : 'search';
+
+    return `${baseUri}?${stringency}=${term}&type=${type}&language=${language}&startDate=${startDate}&endDate=${endDate}`;
   }
 
   function getData(query) {

--- a/client/src/js/main.js
+++ b/client/src/js/main.js
@@ -134,6 +134,14 @@ const DOMBuilder = require('./DOMBuilder');
         properyName: 'page_title'
       },
       {
+        text: 'Topic',
+        properyName: 'article_topic'
+      },
+      {
+        text: 'OA Status',
+        properyName: 'oa_status'
+      },
+      {
         text: 'ID',
         properyName: 'page_id'
       },

--- a/client/src/js/main.js
+++ b/client/src/js/main.js
@@ -35,7 +35,7 @@ const DOMBuilder = require('./DOMBuilder');
     }
 
     const $langPicker = $form.querySelector('#langPicker');
-    const language = $langPicker.options[$langPicker.selectedIndex].value;
+    const language = $langPicker.options[$langPicker.selectedIndex].value.toLowerCase();
 
     const isIdLookup = $form.querySelector('#stringency').checked;
     const stringency = isIdLookup ? 'id' : 'search';

--- a/client/src/js/main.js
+++ b/client/src/js/main.js
@@ -65,16 +65,13 @@ const DOMBuilder = require('./DOMBuilder');
   function displayData(dataString) {
     const data = JSON.parse(dataString);
 
-    if (!data.count) {
-      return;
-    }
+    DOMBuilder.constructResultsHeading(0 + data.count);
 
-    // First page
-    if (!data.previous) {
-      DOMBuilder.constructResultsHeading(data.count);
-      DOMBuilder.constructResultsTable(data.results, config.headRowCols, deriveSourceUri, $searchForm);
-    } else {
+    if (data.previous) {
       DOMBuilder.appendToTableBody(data.results, deriveSourceUri);
+    } else if (data.count) {
+      // First page
+      DOMBuilder.constructResultsTable(data.results, config.headRowCols, deriveSourceUri, $searchForm);
     }
 
     DOMBuilder.constructPager(

--- a/client/src/js/main.js
+++ b/client/src/js/main.js
@@ -21,7 +21,10 @@ const DOMBuilder = require('./DOMBuilder');
     const isIdLookup = $form.querySelector('#stringency').checked;
     const stringency = isIdLookup ? 'id' : 'search';
 
-    return `${baseUri}?${stringency}=${term}&type=${type}&language=${language}&startDate=${startDate}&endDate=${endDate}`;
+    const $orderBy = $form.querySelector('[name="orderBy"]');
+    const orderBy = $orderBy ? $orderBy.value : '';
+
+    return `${baseUri}?${stringency}=${term}&type=${type}&language=${language}&startDate=${startDate}&endDate=${endDate}&orderBy=${orderBy}`;
   }
 
   function getData(query) {
@@ -50,7 +53,7 @@ const DOMBuilder = require('./DOMBuilder');
     // First page
     if (!data.previous) {
       DOMBuilder.constructResultsHeading(data.count);
-      DOMBuilder.constructResultsTable(data.results, config.headRowCols, deriveSourceUri);
+      DOMBuilder.constructResultsTable(data.results, config.headRowCols, deriveSourceUri, $searchForm);
     } else {
       DOMBuilder.appendToTableBody(data.results, deriveSourceUri);
     }
@@ -67,8 +70,10 @@ const DOMBuilder = require('./DOMBuilder');
   }
 
   function handleSubmit(e) {
-    e.preventDefault();
-    e.stopPropagation();
+    if (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
     const $searchResultsContainer = document.querySelector('.search-results');
     DOMBuilder.clear($searchResultsContainer);
     DOMBuilder.constructLoadingSpinner($searchResultsContainer);
@@ -103,19 +108,19 @@ const DOMBuilder = require('./DOMBuilder');
     headRowCols: [
       {
         text: 'Language',
-        href: 'sortByLang_ToggleDirection'
+        properyName: 'language'
       },
       {
         text: 'Title',
-        href: 'sortByTitle_ToggleDirection'
+        properyName: 'page_title'
       },
       {
         text: 'ID',
-        href: 'sortById_ToggleDirection'
+        properyName: 'page_id'
       },
       {
         text: 'Time stamp',
-        href: 'sortByTimeStamp_ToggleDirection'
+        properyName: 'timestamp'
       }
     ]
   };

--- a/client/src/js/main.js
+++ b/client/src/js/main.js
@@ -41,7 +41,7 @@ const DOMBuilder = require('./DOMBuilder');
     console.log('Placeholder fn until search returning results');
     console.log('data', dataString);
     const data = JSON.parse(dataString);
-    DOMBuilder.constructResultsHeading(data);
+    DOMBuilder.constructResultsHeading(data.count);
     DOMBuilder.constructResultsTable(data.results, config.headRowCols, deriveSourceUri);
 
   }
@@ -49,8 +49,9 @@ const DOMBuilder = require('./DOMBuilder');
   function handleSubmit(e) {
     e.preventDefault();
     e.stopPropagation();
+    DOMBuilder.constructLoadingSpinner(document.querySelector('.search-results'));
     getData(composeQuery(e.target))
-      .then(displayData);
+      .then(displayData).then(DOMBuilder.removeLoadingSpinner);
     console.log('query:' ,composeQuery(e.target));
   }
 

--- a/client/src/js/main.js
+++ b/client/src/js/main.js
@@ -41,11 +41,27 @@ const DOMBuilder = require('./DOMBuilder');
     console.log('Placeholder fn until search returning results');
     console.log('data', dataString);
     const data = JSON.parse(dataString);
-    DOMBuilder.constructResultsHeading(data.count);
-    if (data.count) {
-      DOMBuilder.constructResultsTable(data.results, config.headRowCols, deriveSourceUri);
+
+    if (!data.count) {
+      return;
     }
 
+    // First page
+    if (!data.previous) {
+      DOMBuilder.constructResultsHeading(data.count);
+      DOMBuilder.constructResultsTable(data.results, config.headRowCols, deriveSourceUri);
+    } else {
+      DOMBuilder.appendToTableBody(data.results, deriveSourceUri);
+    }
+
+    DOMBuilder.constructPager(
+      {
+        previous: data.previous,
+        next: data.next
+      },
+      getData,
+      displayData
+      );
   }
 
   function handleSubmit(e) {

--- a/client/src/js/main.js
+++ b/client/src/js/main.js
@@ -102,64 +102,6 @@ const DOMBuilder = require('./DOMBuilder');
     ]
   };
 
-  const mockData =   {
-    "count": 5,
-    "next": null,
-    "previous": null,
-    "results": [
-      {
-        "identifier": "780a692c-c37e-45a8-9d86-214787274316",
-        "language": "sw",
-        "page_id": 15871,
-        "page_title": "Malaria",
-        "rev_id": 318169,
-        "timestamp": "2009-11-19T12:35:47Z",
-        "type": "doi",
-        "id": "10.1038/nsmb947"
-      },
-      {
-        "identifier": "780a692c-c37e-45a8-9d86-214787274316",
-        "language": "sw",
-        "page_id": 15871,
-        "page_title": "Malaria",
-        "rev_id": 318169,
-        "timestamp": "2009-11-19T12:35:47Z",
-        "type": "doi",
-        "id": "10.1038/nsmb947"
-      },
-      {
-        "identifier": "780a692c-c37e-45a8-9d86-214787274316",
-        "language": "sw",
-        "page_id": 15871,
-        "page_title": "Malaria",
-        "rev_id": 318169,
-        "timestamp": "2009-11-19T12:35:47Z",
-        "type": "doi",
-        "id": "10.1038/nsmb947"
-      },
-      {
-        "identifier": "780a692c-c37e-45a8-9d86-214787274316",
-        "language": "sw",
-        "page_id": 15871,
-        "page_title": "Malaria",
-        "rev_id": 318169,
-        "timestamp": "2009-11-19T12:35:47Z",
-        "type": "doi",
-        "id": "10.1038/nsmb947"
-      },
-      {
-        "identifier": "780a692c-c37e-45a8-9d86-214787274316",
-        "language": "sw",
-        "page_id": 15871,
-        "page_title": "Malaria",
-        "rev_id": 318169,
-        "timestamp": "2009-11-19T12:35:47Z",
-        "type": "doi",
-        "id": "10.1038/nsmb947"
-      }
-    ]
-  };
-
   $searchForm.addEventListener('submit', handleSubmit);
 
 }(window));

--- a/client/src/scss/base.scss
+++ b/client/src/scss/base.scss
@@ -38,10 +38,6 @@ header {
   margin: 24px 0;
 }
 
-[type="radio"] {
-  margin-right: 12px;
-}
-
 [type="search"] {
   border-radius: 5px;
   border: 1px solid $color-primary;
@@ -126,6 +122,10 @@ legend {
 
 .multi-choice-item {
   line-height: 1.65;
+
+  input {
+    margin-right: 12px;
+  }
 }
 
 .loading-spinner {

--- a/client/src/scss/base.scss
+++ b/client/src/scss/base.scss
@@ -162,15 +162,7 @@ td {
 
   button {
     flex: 0 0 8rem;
-
-    &.previous {
-      margin-right: auto;
-    }
-
-    &.next {
-      margin-left: auto;
-    }
-
+    margin-left: auto;
   }
 
 }

--- a/client/src/scss/base.scss
+++ b/client/src/scss/base.scss
@@ -187,6 +187,7 @@ th {
 
 td {
   line-height: 2;
+  text-align: center; /* temp measure to fix alignment with the th elements */
 }
 
 .pager {

--- a/client/src/scss/base.scss
+++ b/client/src/scss/base.scss
@@ -156,3 +156,12 @@ td {
   line-height: 2;
 }
 
+.pager {
+  display: flex;
+  justify-content: space-between;
+
+  button {
+    flex: 0 0 8rem;
+  }
+
+}

--- a/client/src/scss/base.scss
+++ b/client/src/scss/base.scss
@@ -124,6 +124,10 @@ legend {
   line-height: 1.65;
 }
 
+.loading-spinner {
+  @include loading-spinner();
+}
+
 // Search results
 .search-results {
   width: 100%;
@@ -147,3 +151,4 @@ th {
 td {
   line-height: 2;
 }
+

--- a/client/src/scss/base.scss
+++ b/client/src/scss/base.scss
@@ -25,6 +25,10 @@ a {
   }
 }
 
+.pickers {
+  @include clearfix();
+}
+
 fieldset {
   border-radius: 5px;
 }

--- a/client/src/scss/base.scss
+++ b/client/src/scss/base.scss
@@ -138,6 +138,7 @@ legend {
 }
 
 .search-results__row {
+  animation: fade-in 1s ease-in-out;
   display: grid;
   grid-column-gap: 8px;
   grid-template-columns: 1fr 5fr 2fr 3fr;
@@ -145,6 +146,16 @@ legend {
 
   tbody &:nth-child(even) {
     background-color: $color-text-ui-code;
+  }
+}
+
+@keyframes fade-in {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
   }
 }
 

--- a/client/src/scss/base.scss
+++ b/client/src/scss/base.scss
@@ -162,6 +162,15 @@ td {
 
   button {
     flex: 0 0 8rem;
+
+    &.previous {
+      margin-right: auto;
+    }
+
+    &.next {
+      margin-left: auto;
+    }
+
   }
 
 }

--- a/client/src/scss/base.scss
+++ b/client/src/scss/base.scss
@@ -144,11 +144,16 @@ legend {
   }
 }
 
-.loading-spinner {
-  @include loading-spinner();
+.loading-spinner-wrapper {
+
+  display: flex;
+  justify-content: center;
+
+  .loading-spinner {
+    @include loading-spinner();
+  }
 }
 
-// Search results
 .search-results {
   padding: 0 24px;
   width: 100%;
@@ -191,6 +196,15 @@ td {
   button {
     flex: 0 0 8rem;
     margin-left: auto;
+
+    .loading & {
+      display: none;
+    }
+
   }
 
+}
+
+.heading {
+  margin-right: auto;
 }

--- a/client/src/scss/base.scss
+++ b/client/src/scss/base.scss
@@ -58,8 +58,16 @@ button {
   line-height: 2;
   width: 48%;
 
-  &:hover {
+  &:not(.ordering-control):hover {
     background-color: $color-primary-dark;
+  }
+
+  &.ordering-control {
+    background-color: $color-text--reverse;
+    border-width: 0;
+    color: $color-primary;
+    padding: 0;
+    width: auto;
   }
 
 }

--- a/client/src/scss/base.scss
+++ b/client/src/scss/base.scss
@@ -10,8 +10,16 @@ body {
 
   @media only all and (min-width: #{$breakpoint_2}px) {
     margin: 0 auto;
+  }
+}
+
+.page-header,
+.search-entry {
+  @media only all and (min-width: #{$breakpoint_2}px) {
+    margin: 0 auto;
     max-width: 800px;
   }
+
 }
 
 a {
@@ -142,6 +150,7 @@ legend {
 
 // Search results
 .search-results {
+  padding: 0 24px;
   width: 100%;
 }
 
@@ -149,7 +158,7 @@ legend {
   animation: fade-in 1s ease-in-out;
   display: grid;
   grid-column-gap: 8px;
-  grid-template-columns: 1fr 5fr 2fr 3fr;
+  grid-template-columns: 1fr 5fr 3fr 2fr 2fr 3fr;
   width: 100%;
 
   tbody &:nth-child(even) {

--- a/client/src/scss/build.scss
+++ b/client/src/scss/build.scss
@@ -1,4 +1,5 @@
 @import "variables";
 @import "normalize";
+@import "mixins";
 
 @import "base";

--- a/client/src/scss/mixins.scss
+++ b/client/src/scss/mixins.scss
@@ -1,0 +1,22 @@
+@mixin loading-spinner($torus-width: 5, $size: 22, $highlight-color: rgba(255, 255, 255, 0.2), $base-color: $color-primary) {
+  animation: full-rotation 1.1s infinite linear;
+  border: #{$torus-width}px solid $base-color;
+  border-left: #{$torus-width}px solid $highlight-color;
+  border-radius: 50%;
+  display: block;
+  height: #{$size}px;
+  overflow: hidden;
+  text-indent: -9999em;
+  transform: translateZ(0);
+  width: #{$size}px;
+
+  @keyframes full-rotation {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+
+}

--- a/client/src/scss/mixins.scss
+++ b/client/src/scss/mixins.scss
@@ -1,3 +1,15 @@
+@mixin clearfix() {
+  &:before,
+  &:after {
+    content: "";
+    display: table;
+  }
+
+  &:after {
+    clear: both;
+  }
+}
+
 @mixin loading-spinner($torus-width: 5, $size: 22, $highlight-color: rgba(255, 255, 255, 0.2), $base-color: $color-primary) {
   animation: full-rotation 1.1s infinite linear;
   border: #{$torus-width}px solid $base-color;

--- a/client/src/search-UI-prototypes.html
+++ b/client/src/search-UI-prototypes.html
@@ -24,11 +24,13 @@
         <input class="text-input" type="search" name="search" placeholder="10.nnnn.nn formatted search">
         <button class="button" type="submit">Search</button>
 
+        <div class="multi-choice-item"><input type="checkbox" name="stringency" value="exact match" id="stringency" checked/><label for="stringency">Exact match</label></div>
+
 
         <fieldset class="id-type-wrapper">
           <legend>Which type of identifier are you searching with? </legend>
 
-          <div class="multi-choice-item"><input type="radio" name="type" value="doi" id="idPickerDOI"/><label for="idPickerDOI">DOI</label></div>
+          <div class="multi-choice-item"><input type="radio" name="type" value="doi" id="idPickerDOI" checked/><label for="idPickerDOI" >DOI</label></div>
           <div class="multi-choice-item"><input type="radio" name="type" value="isbn" id="idPickerISBN" /><label for="idPickerISBN">ISBN</label></div>
           <div class="multi-choice-item"><input type="radio" name="type" value="arxiv" id="idPickerARXIV" /><label for="idPickerARXIV">ARXIV</label></div>
           <div class="multi-choice-item"><input type="radio" name="type" value="pmid" id="idPickerPMID" /><label for="idPickerPMID">PubMed ID</label></div>

--- a/client/src/search-UI-prototypes.html
+++ b/client/src/search-UI-prototypes.html
@@ -177,6 +177,11 @@
 
       </table>
 
+      <div class="pager">
+        <button id="nextPage">Previous</button>
+        <button id="previousPage">Next</button>
+      </div>
+
     </section>
 
 

--- a/client/src/search-UI-prototypes.html
+++ b/client/src/search-UI-prototypes.html
@@ -178,8 +178,8 @@
       </table>
 
       <div class="pager">
-        <button id="nextPage">Previous</button>
-        <button id="previousPage">Next</button>
+        <button id="previousPage" class="previous">Previous</button>
+        <button id="nextPage" class="next">Next</button>
       </div>
 
     </section>

--- a/client/src/search-UI-prototypes.html
+++ b/client/src/search-UI-prototypes.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <title>WikiCiteVis: Search UI prototype</title>
   <link rel="stylesheet" href="css/all.css">
+  <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
+  <meta name="format-detection" content="telephone=no">
 </head>
 <body>
 


### PR DESCRIPTION
- Loads real data
- Allows ordering by any of the displayed fields by clicking on the column heading. The first click imposes ascending order, a consecutive click on the same column heading imposes descending order
- Allows searching by any single language, or all languages
- Includes the new fields Topic and OA Status (linking to OA URL where available)
- adds link to diff via timestamp
- fixes links in id column
- Display result count of 0 when no results returned
- Loading spinner placement Improvement

Note that are quite a few OA URLs coming out as `nan`. This appears to be a data problem and not a UI problem.